### PR TITLE
Fix case then doted index is longer than array

### DIFF
--- a/src/Stingray.php
+++ b/src/Stingray.php
@@ -2,6 +2,8 @@
 
 namespace Rwillians\Stingray;
 
+use ArrayAccess;
+
 
 /**
  * Class Stingray.
@@ -24,16 +26,29 @@ class Stingray
     {
         $paths = explode('.', $path);
         $node  = &$data;
+        $isArrayLike = self::isArrayLike($data);
 
         foreach ($paths as $nextPath) {
-            if (!array_key_exists($nextPath, $node)) {
+            if (!$isArrayLike || !array_key_exists($nextPath, $node)) {
                 return null;
             }
 
             $node = &$node[$nextPath];
+            $isArrayLike = self::isArrayLike($node);
         }
 
         return $node;
+    }
+
+    /**
+     * Check value is array like
+     * This can be an array or object witch implements ArrayAccess interface
+     *
+     * @param $data
+     * @return bool
+     */
+    public static function isArrayLike($data){
+        return (is_array($data) || $data instanceof ArrayAccess );
     }
 
     /**

--- a/src/Stingray.php
+++ b/src/Stingray.php
@@ -2,15 +2,13 @@
 
 namespace Rwillians\Stingray;
 
-use ArrayAccess;
-
-
 /**
  * Class Stingray.
  * Get or Set array node using dot notation.
  *
  * @author Matthew Ratzke <matthew.003@me.com>
  * @author Rafael Willians <me@rwillians.com>
+ * @author Ivan Pyankov <unit.1985@gmail.com>
  */
 class Stingray
 {
@@ -25,39 +23,37 @@ class Stingray
     public static function get(&$data, $path)
     {
         $paths = explode('.', $path);
+        $length = count($paths) - 1;
+        $node = &$data;
 
-        if (!is_object($data)) {
-            $node = &$data;
-        } else {
-            $node = $data;
-        }
-
-        $isArrayLike = self::isArrayLike($data);
-
-        foreach ($paths as $nextPath) {
-            if (!$isArrayLike || !array_key_exists($nextPath, $node)) {
+        foreach ($paths as $idx => $nextPath) {
+            if (!self::isArrayLike($node) || !array_key_exists($nextPath, $node)) {
                 return null;
             }
-
-            if(!is_object($node)){
+            if (self::isArrayLike($node[$nextPath])) {
                 $node = &$node[$nextPath];
-            }else{
-                $node = $node[$nextPath];
+                continue;
             }
-            $isArrayLike = self::isArrayLike($node);
+            if ($idx < $length) {
+                return null;
+            }
+            if ($idx === $length) {
+                return $node[$nextPath];
+            }
         }
+
         return $node;
     }
 
     /**
      * Check value is array like
-     * This can be an array or object witch implements ArrayAccess interface
+     * This can be an array or object witch implementation of ArrayAccess interface
      *
-     * @param &$data
+     * @param $data
      * @return bool
      */
-    public static function isArrayLike(&$data){
-        return (is_array($data) || $data instanceof ArrayAccess );
+    public static function isArrayLike($data){
+        return is_array($data) || $data instanceof \ArrayAccess ;
     }
 
     /**

--- a/src/Stingray.php
+++ b/src/Stingray.php
@@ -15,33 +15,22 @@ class Stingray
     /**
      * Get's the value from an array using dot notation.
      *
-     * @param array  &$data Multidimensional array being searched
+     * @param array $data Multidimensional array being searched
      * @param string $path Dot notation string path to be searched within the multidimensional array.
      *
      * @return mixed Returns null in the the requested path couldn't be found.
      */
-    public static function get(&$data, $path)
+    public static function get($data, $path)
     {
         $paths = explode('.', $path);
-        $length = count($paths) - 1;
-        $node = &$data;
+        $node = $data;
 
         foreach ($paths as $idx => $nextPath) {
             if (!static::isArrayLike($node) || !array_key_exists($nextPath, $node)) {
                 return null;
             }
-            if (static::isArrayLike($node[$nextPath])) {
-                $node = &$node[$nextPath];
-                continue;
-            }
-            if ($idx < $length) {
-                return null;
-            }
-            if ($idx === $length) {
-                return $node[$nextPath];
-            }
+            $node = $node[$nextPath];
         }
-
         return $node;
     }
 
@@ -52,25 +41,26 @@ class Stingray
      * @param $data
      * @return bool
      */
-    protected static function isArrayLike($data){
-        return is_array($data) || $data instanceof \ArrayAccess ;
+    protected static function isArrayLike($data)
+    {
+        return is_array($data) || $data instanceof \ArrayAccess;
     }
 
     /**
      * Set's a value to an array node using dot notation.
      *
-     * @param array  &$data Array being searched.
+     * @param array &$data Array being searched.
      * @param string $path Path used to search array.
-     * @param mixed  $value Value to set array node.
+     * @param mixed $value Value to set array node.
      *
      * @return bool
      */
     public static function set(&$data, $path, $value)
     {
-        $paths            = explode('.', $path);
-        $pathCount        = count($paths);
+        $paths = explode('.', $path);
+        $pathCount = count($paths);
         $currentIteration = 0;
-        $node             = &$data;
+        $node = &$data;
 
         foreach ($paths as $nextPath) {
             if (array_key_exists($nextPath, $node)) {
@@ -78,7 +68,7 @@ class Stingray
                 $currentIteration++;
             } elseif ($currentIteration < $pathCount) {
                 $node[$nextPath] = [];
-                $node            = &$node[$nextPath];
+                $node = &$node[$nextPath];
                 $currentIteration++;
             }
         }

--- a/src/Stingray.php
+++ b/src/Stingray.php
@@ -25,7 +25,13 @@ class Stingray
     public static function get(&$data, $path)
     {
         $paths = explode('.', $path);
-        $node  = &$data;
+
+        if (!is_object($data)) {
+            $node = &$data;
+        } else {
+            $node = $data;
+        }
+
         $isArrayLike = self::isArrayLike($data);
 
         foreach ($paths as $nextPath) {
@@ -33,10 +39,13 @@ class Stingray
                 return null;
             }
 
-            $node = &$node[$nextPath];
+            if(!is_object($node)){
+                $node = &$node[$nextPath];
+            }else{
+                $node = $node[$nextPath];
+            }
             $isArrayLike = self::isArrayLike($node);
         }
-
         return $node;
     }
 
@@ -44,10 +53,10 @@ class Stingray
      * Check value is array like
      * This can be an array or object witch implements ArrayAccess interface
      *
-     * @param $data
+     * @param &$data
      * @return bool
      */
-    public static function isArrayLike($data){
+    public static function isArrayLike(&$data){
         return (is_array($data) || $data instanceof ArrayAccess );
     }
 

--- a/src/Stingray.php
+++ b/src/Stingray.php
@@ -27,10 +27,10 @@ class Stingray
         $node = &$data;
 
         foreach ($paths as $idx => $nextPath) {
-            if (!self::isArrayLike($node) || !array_key_exists($nextPath, $node)) {
+            if (!static::isArrayLike($node) || !array_key_exists($nextPath, $node)) {
                 return null;
             }
-            if (self::isArrayLike($node[$nextPath])) {
+            if (static::isArrayLike($node[$nextPath])) {
                 $node = &$node[$nextPath];
                 continue;
             }
@@ -52,7 +52,7 @@ class Stingray
      * @param $data
      * @return bool
      */
-    public static function isArrayLike($data){
+    protected static function isArrayLike($data){
         return is_array($data) || $data instanceof \ArrayAccess ;
     }
 

--- a/tests/Fixtures/ArrayLikeObject.php
+++ b/tests/Fixtures/ArrayLikeObject.php
@@ -1,0 +1,100 @@
+<?php
+
+class ArrayLikeObject implements ArrayAccess
+{
+
+    private $pool = array();
+
+
+    public function __construct(array $array)
+    {
+        foreach ($array as $key => $item) {
+            if (is_array($item)) {
+                $item = new self($item);
+            }
+            $this->{$key} = $item;
+            $this->pool[] = $key;
+        }
+    }
+
+    /**
+     * Whether a offset exists
+     * @link http://php.net/manual/en/arrayaccess.offsetexists.php
+     * @param mixed $offset <p>
+     * An offset to check for.
+     * </p>
+     * @return boolean true on success or false on failure.
+     * </p>
+     * <p>
+     * The return value will be casted to boolean if non-boolean was returned.
+     * @since 5.0.0
+     */
+    public function offsetExists($offset)
+    {
+        return property_exists($this, $offset);
+    }
+
+    /**
+     * Offset to retrieve
+     * @link http://php.net/manual/en/arrayaccess.offsetget.php
+     * @param mixed $offset <p>
+     * The offset to retrieve.
+     * </p>
+     * @return mixed Can return all value types.
+     * @since 5.0.0
+     */
+    public function offsetGet($offset)
+    {
+        return $this->{$offset};
+    }
+
+    /**
+     * Offset to set
+     * @link http://php.net/manual/en/arrayaccess.offsetset.php
+     * @param mixed $offset <p>
+     * The offset to assign the value to.
+     * </p>
+     * @param mixed $value <p>
+     * The value to set.
+     * </p>
+     * @return void
+     * @since 5.0.0
+     */
+    public function offsetSet($offset, $value)
+    {
+        if (is_array($value)) {
+            $value = new self($value);
+        }
+        $this->pool[] = $offset;
+        $this->{$offset} = $value;
+    }
+
+    /**
+     * Offset to unset
+     * @link http://php.net/manual/en/arrayaccess.offsetunset.php
+     * @param mixed $offset <p>
+     * The offset to unset.
+     * </p>
+     * @return void
+     * @since 5.0.0
+     */
+    public function offsetUnset($offset)
+    {
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        $resultArray = array();
+        foreach ($this->pool as $key) {
+            $item = $this->{$key};
+            if ($item instanceof self ) {
+                $item = $item->toArray();
+            }
+            $resultArray[$key] = $item;
+        }
+        return $resultArray;
+    }
+}

--- a/tests/StingrayTest.php
+++ b/tests/StingrayTest.php
@@ -9,20 +9,56 @@ use Rwillians\Stingray\Stingray;
  */
 class StingrayTest extends PHPUnit_Framework_TestCase
 {
-    public function testItCanGetValues()
+    public function testItCanGetValuesForArrays()
     {
         $array = [
             'test_1' => 'value_1',
             'test_2' => [
                 'test_2_1' => 'value_2'
-            ]
+            ],
+            'test_3' => [
+                'test_3_1' => [ 'value_3' ]
+            ],
+            'value_4',
         ];
 
         $stingray = new Stingray();
 
         $this->assertEquals('value_1', $stingray::get($array, 'test_1'));
         $this->assertEquals('value_2', $stingray::get($array, 'test_2.test_2_1'));
+        $this->assertEquals('value_3', $stingray::get($array, 'test_3.test_3_1.0'));
+        $this->assertEquals('value_4', $stingray::get($array, 0));
+        $this->assertEquals(null, $stingray::get($array, 'test_2.test_2_1.value_2'));
+        $this->assertEquals(null, $stingray::get($array, 'test_2.test_2_1.value_3'));
+        $this->assertEquals(null, $stingray::get($array, 'test_2.test_2_1.value_2.value_3'));
         $this->assertEquals(null, $stingray::get($array, 'non.existent.path'));
+    }
+
+    public function testItCanGetValuesForArrayLikeObjects()
+    {
+        $array = [
+            'test_1' => 'value_1',
+            'test_2' => [
+                'test_2_1' => 'value_2'
+            ],
+            'test_3' => [
+                'test_3_1' => [ 'value_3' ]
+            ],
+            'value_4',
+        ];
+
+        $object = new ArrayObject($array);
+
+        $stingray = new Stingray();
+
+        $this->assertEquals('value_1', $stingray::get($object, 'test_1'));
+        $this->assertEquals('value_2', $stingray::get($object, 'test_2.test_2_1'));
+        $this->assertEquals('value_3', $stingray::get($object, 'test_3.test_3_1.0'));
+        $this->assertEquals('value_4', $stingray::get($object, 0));
+        $this->assertEquals(null, $stingray::get($object, 'test_2.test_2_1.value_2'));
+        $this->assertEquals(null, $stingray::get($object, 'test_2.test_2_1.value_3'));
+        $this->assertEquals(null, $stingray::get($object, 'test_2.test_2_1.value_2.value_3'));
+        $this->assertEquals(null, $stingray::get($object, 'non.existent.path'));
     }
 
     public function testItCanSetAnValue()

--- a/tests/StingrayTest.php
+++ b/tests/StingrayTest.php
@@ -15,50 +15,17 @@ class StingrayTest extends PHPUnit_Framework_TestCase
             'test_1' => 'value_1',
             'test_2' => [
                 'test_2_1' => 'value_2'
-            ],
-            'test_3' => [
-                'test_3_1' => [ 'value_3' ]
-            ],
-            'value_4',
+            ]
         ];
 
         $stingray = new Stingray();
 
         $this->assertEquals('value_1', $stingray::get($array, 'test_1'));
         $this->assertEquals('value_2', $stingray::get($array, 'test_2.test_2_1'));
-        $this->assertEquals('value_3', $stingray::get($array, 'test_3.test_3_1.0'));
-        $this->assertEquals('value_4', $stingray::get($array, 0));
-        $this->assertEquals(null, $stingray::get($array, 'test_2.test_2_1.value_2'));
-        $this->assertEquals(null, $stingray::get($array, 'test_2.test_2_1.value_3'));
-        $this->assertEquals(null, $stingray::get($array, 'test_2.test_2_1.value_2.value_3'));
-        $this->assertEquals(null, $stingray::get($array, 'non.existent.path'));
-    }
-
-    public function testItCanGetValuesForArrayLikeObjects()
-    {
-        $array = [
-            'test_1' => 'value_1',
-            'test_2' => [
-                'test_2_1' => 'value_2'
-            ],
-            'test_3' => [
-                'test_3_1' => [ 'value_3' ]
-            ],
-            'value_4',
-        ];
-
-        $object = new ArrayObject($array);
-
-        $stingray = new Stingray();
-
-        $this->assertEquals('value_1', $stingray::get($object, 'test_1'));
-        $this->assertEquals('value_2', $stingray::get($object, 'test_2.test_2_1'));
-        $this->assertEquals('value_3', $stingray::get($object, 'test_3.test_3_1.0'));
-        $this->assertEquals('value_4', $stingray::get($object, 0));
-        $this->assertEquals(null, $stingray::get($object, 'test_2.test_2_1.value_2'));
-        $this->assertEquals(null, $stingray::get($object, 'test_2.test_2_1.value_3'));
-        $this->assertEquals(null, $stingray::get($object, 'test_2.test_2_1.value_2.value_3'));
-        $this->assertEquals(null, $stingray::get($object, 'non.existent.path'));
+        $this->assertNull($stingray::get($array, 'non.existent.path'));
+        $this->assertNull($stingray::get($array, 'test_2.test_2_1.value_2'));
+        $this->assertNull($stingray::get($array, 'test_2.test_2_1.value_2.non-existent'));
+        $this->assertNull($stingray::get($array, 'test_2.test_2_1.non-existent'));
     }
 
     public function testItCanSetAnValue()

--- a/tests/StingrayTest.php
+++ b/tests/StingrayTest.php
@@ -2,7 +2,7 @@
 
 use Rwillians\Stingray\Stingray;
 
-
+require __DIR__.'/Fixtures/ArrayLikeObject.php';
 /**
  * Class StingrayTest
  * @author Rafael Willians <me@rwillians.com>
@@ -26,6 +26,36 @@ class StingrayTest extends PHPUnit_Framework_TestCase
         $this->assertNull($stingray::get($array, 'test_2.test_2_1.value_2'));
         $this->assertNull($stingray::get($array, 'test_2.test_2_1.value_2.non-existent'));
         $this->assertNull($stingray::get($array, 'test_2.test_2_1.non-existent'));
+    }
+
+
+    public function testItCanGetValuesForArrayLikeObject()
+    {
+        $arr = [
+            'a' => [
+                'b' => [
+                    'c' => [
+                        'd' => 'e'
+                    ]
+                ]
+            ],
+            'f' => 'h'
+        ];
+
+        $config = new \ArrayLikeObject($arr);
+        $this->assertEquals($arr['a'], Stingray::get($config, 'a')->toArray());
+
+        $this->assertEquals($arr['a']['b'], Stingray::get($config, 'a.b')->toArray());
+
+        $this->assertEquals($arr['a']['b']['c'], Stingray::get($config, 'a.b.c')->toArray());
+        $this->assertEquals($arr['a']['b']['c']['d'], Stingray::get($config, 'a.b.c.d'));
+        $this->assertEquals($arr['f'], Stingray::get($config, 'f'));
+
+        $this->assertNull(Stingray::get($config, 'a.b.d'));
+        $this->assertNull(Stingray::get($config, 'a.b.c.d.e.f.g'));
+
+        $this->assertEquals($arr, $config->toArray());
+
     }
 
     public function testItCanSetAnValue()


### PR DESCRIPTION
Hi i would be happy if you accept my pull request, this pull request for situation then you try get doted index longer then you have,
ex:

``` php
$array = [
            'a' => [
                'b' => [
                    'c' => [
                        'd' => 'e'
                    ]
                ]
            ]
        ];
Stingray::get($arr,'a.b.c.d.e.f.g');
```

With old behavior we get: 
array_key_exists() expects parameter 2 to be array, string given
